### PR TITLE
Fix references versions (NewtonSoft and Azure Storage)

### DIFF
--- a/TelscoDemo/WebRole1/WebRole1.csproj
+++ b/TelscoDemo/WebRole1/WebRole1.csproj
@@ -133,9 +133,8 @@
       <HintPath>..\packages\WindowsAzure.Storage.6.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -1188,7 +1187,9 @@
     <Content Include="fonts\glyphicons-halflings-regular.woff" />
     <Content Include="fonts\glyphicons-halflings-regular.ttf" />
     <Content Include="fonts\glyphicons-halflings-regular.eot" />
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Project_Readme.html" />
     <Content Include="Scripts\jquery-1.10.2.min.map" />
   </ItemGroup>

--- a/TelscoDemo/WebRole1/packages.config
+++ b/TelscoDemo/WebRole1/packages.config
@@ -47,7 +47,7 @@
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />

--- a/TelscoDemo/WebRole1/web.config
+++ b/TelscoDemo/WebRole1/web.config
@@ -100,7 +100,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Fix references. Incorrect versions caused Insights calls to get metrics to fail
